### PR TITLE
Refactor multiplexing detection to allow plate names to remain unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ You can add these Fractal tasks to a server by using the pypi installation and s
 
 ## Making releases
 1. Merge PR into main
-2. Locally checkout main
-3. Tag the release: git tag v0.4.3
-4. Push the tag to Github: git push origin v0.4.3
+2. Create a Github release with a new tag
 
 The github workflow will then publish this release to PyPI & create a Github release with the corresponding whl file.
+
+## Updating the Fractal manifest
+
+Whenever any input parameters or their docstrings change, run:
+
+```
+fractal-manifest create --package fractal-faim-ipa
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "fractal-tasks-core==1.5.0",
     "pydantic",
     "zarr",
     "faim-ipa==0.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fractal-tasks-core==1.5.0",
+    "fractal-tasks-core==1.5.6",
     "pydantic",
     "zarr",
     "faim-ipa==0.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "fractal-tasks-core==1.5.0",
     "pydantic",
     "zarr",
     "faim-ipa==0.13.0",
-    "fractal-task-tools==0.0.12",
+    "fractal-task-tools>=0.1.1",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
@@ -30,7 +30,7 @@
               "plate_name": {
                 "title": "Plate Name",
                 "type": "string",
-                "description": "Optional custom name for the plate. If not provided, the name will be the acquisition directory name."
+                "description": "Optional custom name for the plate. If not provided, the name will be the acquisition directory name. For multiplexing, all plates need to be set to have the same plate name. For non-multiplexing (e.g. processing a series of plate), all plates need to have unique names."
               },
               "acquisition_id": {
                 "default": 0,
@@ -168,7 +168,7 @@
               "plate_name": {
                 "title": "Plate Name",
                 "type": "string",
-                "description": "Optional custom name for the plate. If not provided, the name will be the acquisition directory name."
+                "description": "Optional custom name for the plate. If not provided, the name will be the acquisition directory name. For multiplexing, all plates need to be set to have the same plate name. For non-multiplexing (e.g. processing a series of plate), all plates need to have unique names."
               },
               "acquisition_id": {
                 "default": 0,

--- a/src/fractal_faim_ipa/convert_md_to_ome_zarr.py
+++ b/src/fractal_faim_ipa/convert_md_to_ome_zarr.py
@@ -89,6 +89,10 @@ def convert_md_to_ome_zarr(  # noqa: C901
     zarr_dir = zarr_dir.rstrip("/")
     image_list_updates = []
 
+    for acquisition in acquisitions:
+        if acquisition.plate_name is None:
+            acquisition.plate_name = acquisition.path.rstrip("/").split("/")[-1]
+
     is_multiplexed = check_is_multiplexing(acquisitions)
     if is_multiplexed:
         logger.info(
@@ -104,10 +108,6 @@ def convert_md_to_ome_zarr(  # noqa: C901
     # (the Zarr file gets a newer timestamp at least)
     # This block triggers a reset
     for acquisition in acquisitions:
-        plate_name = acquisition.plate_name
-        if plate_name is None:
-            plate_name = acquisition.path.rstrip("/").split("/")[-1]
-
         # Check if folder exists. faim-ipa errors when wrong paths are
         # entered are often confusing to users. Fail early if an input path
         # doesn't even exist / isn't accessible.
@@ -118,13 +118,13 @@ def convert_md_to_ome_zarr(  # noqa: C901
                 "manner that is accessible from where the task is run."
             )
 
-        if exists(join(zarr_dir, plate_name + ".zarr")):
+        if exists(join(zarr_dir, acquisition.plate_name + ".zarr")):
             if reset_plates:
                 # Remove zarr if it already exists.
-                shutil.rmtree(join(zarr_dir, plate_name + ".zarr"))
+                shutil.rmtree(join(zarr_dir, acquisition.plate_name + ".zarr"))
             else:
                 logger.warning(
-                    f"Zarr file {plate_name + '.zarr'} already "
+                    f"Zarr file {acquisition.plate_name + '.zarr'} already "
                     f"exists and wasn't reset due to {reset_plates=}. This "
                     "may lead to unexpected behavior.",
                 )
@@ -141,10 +141,6 @@ def convert_md_to_ome_zarr(  # noqa: C901
         )
 
     for acquisition in acquisitions:
-        plate_name = acquisition.plate_name
-        if plate_name is None:
-            plate_name = acquisition.path.rstrip("/").split("/")[-1]
-
         plate_acquisition = mode.get_plate_acquisition(
             acquisition_dir=acquisition.path,
             alignment=tile_alignment,
@@ -153,7 +149,7 @@ def convert_md_to_ome_zarr(  # noqa: C901
         converter = ConvertToNGFFPlate(
             ngff_plate=NGFFPlate(
                 root_dir=zarr_dir,
-                name=plate_name,
+                name=acquisition.plate_name,
                 layout=int(layout),
                 order_name=order_name,
                 barcode=barcode,
@@ -169,7 +165,7 @@ def convert_md_to_ome_zarr(  # noqa: C901
         well_sub_group = str(acquisition.acquisition_id)
         well_acquisitions = plate_acquisition.get_well_acquisitions(selection=None)
 
-        full_plate_name = plate_name + ".zarr"
+        full_plate_name = acquisition.plate_name + ".zarr"
 
         # TODO: Add more robust handling for dimensionality detection
         if mode == ModeEnum.SinglePlaneAcquisition:

--- a/src/fractal_faim_ipa/converter_utils.py
+++ b/src/fractal_faim_ipa/converter_utils.py
@@ -13,8 +13,11 @@ class AcquisitionInputModel(BaseModel):
             that contains a date folder and an ID folder. If the images are in
             /path/to/project_name/2025-05-12/1234, then the path should be
             /path/to/project_name.
-        plate_name: Optional custom name for the plate. If not provided, the name will
-            be the acquisition directory name.
+        plate_name: Optional custom name for the plate. If not provided,
+            the name will be the acquisition directory name. For multiplexing,
+            all plates need to be set to have the same plate name. For
+            non-multiplexing (e.g. processing a series of plate), all plates
+            need to have unique names.
         acquisition_id: Acquisition ID,
             used to identify the acquisition in case of multiple acquisitions.
     """
@@ -68,21 +71,38 @@ def check_is_multiplexing(acquisitions: list[AcquisitionInputModel]):
     plate_names = [acquisition.plate_name for acquisition in acquisitions]
     acquisition_ids = [acquisition.acquisition_id for acquisition in acquisitions]
 
-    if len(plate_names) == 0:
+    if len(acquisitions) == 0:
         raise ValueError("No plate acquisitions provided. Please check your input.")
-
-    if len(plate_names) == 1:
+    elif len(acquisitions) == 1:
         return False
-    if len(set(plate_names)) == 1:
-        # All the same plate name
-        if len(set(acquisition_ids)) == len(acquisition_ids):
-            # All the acquisition IDs are unique
+    else:
+        # Cases with more than 1 acquisiton specified
+        if len(set(plate_names)) == len(acquisitions):
+            # Unique plate names => non-multiplexing
+            return False
+        elif len(set(plate_names)) > 1 and len(set(plate_names)) < len(acquisitions):
+            if len(set(acquisition_ids)) == len(acquisitions):
+                raise ValueError(
+                    "Inconsistent plate names for multiplexing experiments. "
+                    "All plate names should be the same for multiplexing.",
+                )
+            else:
+                raise ValueError(
+                    "Inconsistent plate names & acquisition IDs were provided. "
+                    "Either all plate names need to be unique (for "
+                    "non-multiplexing) or all plate names need to be the same "
+                    "but with unique acquisition Ids.",
+                )
+        elif len(set(plate_names)) == 1 and len(set(acquisition_ids)) == len(
+            acquisitions
+        ):
+            # All same plate name & unique acquisition IDs => multiplexing
             return True
         else:
             raise ValueError(
-                "Acquisition IDs should be unique for multiplexing "
-                "experiments. Please check your input.",
+                "Acquisition plate names & IDs are not valid. Please check "
+                "your input."
+                "Either all plate names need to be unique (for "
+                "non-multiplexing) or all plate names need to be the same "
+                "but with unique acquisition Ids."
             )
-    else:
-        # All the plate names are different
-        return False

--- a/tests/test_md_converter_task.py
+++ b/tests/test_md_converter_task.py
@@ -14,6 +14,10 @@ from fractal_faim_ipa.converter_utils import (
 )
 
 
+def sort_key(item):
+    return item["zarr_url"]
+
+
 def count_arrays_in_group(group_url: str) -> int:
     """
     Count the number of arrays in a Zarr group.
@@ -331,7 +335,10 @@ def test_ome_zarr_conversion_multiplex(tmp_path):
             },
         },
     ]
-    assert expected_image_list_update == image_list_update
+
+    assert sorted(image_list_update, key=sort_key) == sorted(
+        expected_image_list_update, key=sort_key
+    )
 
 
 def test_ome_zarr_conversion_multi_plate(tmp_path):
@@ -396,7 +403,9 @@ def test_ome_zarr_conversion_multi_plate(tmp_path):
             },
         },
     ]
-    assert expected_image_list_update == image_list_update
+    assert sorted(image_list_update, key=sort_key) == sorted(
+        expected_image_list_update, key=sort_key
+    )
 
 
 def test_ome_zarr_conversion_failure_non_existing_path(tmp_path):

--- a/tests/test_md_converter_task.py
+++ b/tests/test_md_converter_task.py
@@ -8,6 +8,10 @@ import anndata as ad
 import pytest
 import zarr
 from fractal_faim_ipa.convert_md_to_ome_zarr import convert_md_to_ome_zarr
+from fractal_faim_ipa.converter_utils import (
+    AcquisitionInputModel,
+    check_is_multiplexing,
+)
 
 
 def count_arrays_in_group(group_url: str) -> int:
@@ -422,3 +426,66 @@ def test_ome_zarr_conversion_failure_non_existing_path(tmp_path):
             barcode=barcode,
             reset_plates=reset_plates,
         )
+
+
+acquisitions = {
+    "multiplexing": [
+        [
+            AcquisitionInputModel(
+                path="/path/to/plate1", plate_name="plate1", acquisition_id=1
+            ),
+            AcquisitionInputModel(
+                path="/path/to/plate2", plate_name="plate1", acquisition_id=2
+            ),
+        ],
+    ],
+    "multi_plate": [
+        [
+            AcquisitionInputModel(
+                path="/path/to/plate1", plate_name="plate1", acquisition_id=1
+            ),
+            AcquisitionInputModel(
+                path="/path/to/plate2", plate_name="plate2", acquisition_id=2
+            ),
+        ],
+        [
+            AcquisitionInputModel(path="/path/to/plate1", plate_name="plate1"),
+            AcquisitionInputModel(path="/path/to/plate2", plate_name="plate2"),
+        ],
+    ],
+    "single_plate": [
+        [
+            AcquisitionInputModel(
+                path="/path/to/plate1", plate_name="plate1", acquisition_id=1
+            ),
+        ]
+    ],
+    "invalid": [
+        [
+            AcquisitionInputModel(
+                path="/path/to/plate1", plate_name="plate1", acquisition_id=1
+            ),
+            AcquisitionInputModel(
+                path="/path/to/plate2", plate_name="plate1", acquisition_id=1
+            ),
+        ],
+        [],
+        [
+            AcquisitionInputModel(path="/path/to/plate1", plate_name="plate1"),
+            AcquisitionInputModel(path="/path/to/plate2", plate_name="plate1"),
+        ],
+    ],
+}
+
+
+def test_plate_name_acquisition_constraints():
+    for multiplexing_acq in acquisitions["multiplexing"]:
+        assert check_is_multiplexing(multiplexing_acq) is True
+    for multi_plate_acq in acquisitions["multi_plate"]:
+        print(multi_plate_acq)
+        assert check_is_multiplexing(multi_plate_acq) is False
+    for single_plate_acq in acquisitions["single_plate"]:
+        assert check_is_multiplexing(single_plate_acq) is False
+    for invalid_acq in acquisitions["invalid"]:
+        with pytest.raises(ValueError):
+            check_is_multiplexing(invalid_acq)


### PR DESCRIPTION
Improves the multiplexing checks such that plate names don't need to be specified when there are multiple non-multiplexing plates and they get unique names through the plate name detection from the folder name